### PR TITLE
fix broken Discord invite link and clarify project sharing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,4 +13,4 @@
   - Add a directory named after the dataset with the README file.
   - Commit and push the changes to GitHub.
   - Create a pull request on GitHub.
-- Optional: Share the project in the `#hacktoberfest` channel on the DagsHub [Discord server](https://discord.com/invite/9gU36Y6).
+- Optional: Share the project in the `#hacktoberfest` channel on the [DagsHub Discord server](https://discord.com/invite/9gU36Y6).


### PR DESCRIPTION
The Discord link on the [`CONTRIBUTING.md`](https://github.com/DAGsHub/audio-datasets/blob/main/CONTRIBUTING.md) page is invalid. I found a valid link on the [DAGsHub homepage](https://dagshub.com/). To make sure the link is valid, I used it to join the DAGsHub Discord server.

The instructions for sharing a project on Discord were not super clear to someone unfamiliar with Discord.

> Optional: Share the project on DagsHub Hacktoberfest 2021 Discord channel

It sounded like there was a separate DAGsHub Discord server specifically for Hacktoberfest 2021. Coupled with the broken invite link, this could imply that that Hacktoberfest 2021 server is offline.

I tried to clarify the instructions to match what I believe to be the most likely situation: people can share projects in the `#hacktoberfest` channel on the DAGsHub Discord server. I hope this is right. If there's anything I missed, please let me know. Since Hacktoberfest ends on October 31, I would suggest not mentioning it in the instructions and instead mention the #share-your-project channel.

I see that #63 also wants to fix this same broken link but in `README.md`. I didn't want to create a conflicting PR or interfere with that PR. Please let me know if I should do anything differently.

![image](https://user-images.githubusercontent.com/24983797/138550400-573a3ef9-1c44-45ed-a5cc-dfb7eaa51149.png)

![image](https://user-images.githubusercontent.com/24983797/138550515-6da727a2-36ec-4696-8efc-0d61151a166b.png)

![image](https://user-images.githubusercontent.com/24983797/138550462-7acd72d7-b86a-4bdf-ab63-d330fb1f0182.png)
